### PR TITLE
Internationalization changes for output and input file

### DIFF
--- a/cruziwords/__main__.py
+++ b/cruziwords/__main__.py
@@ -19,7 +19,7 @@ def parse_args() -> argparse.Namespace:
         "csv_path", nargs="?", type=Path, default=random_example(), help="CSV file containing word definitions"
     )
     argp.add_argument("--max-iterations", type=int, help="Number of parallel random searches")
-    argp.add_argument("--html-out", type=FileType("w"), help="Output board as HTML to this file")
+    argp.add_argument("--html-out", type=FileType("w", encoding="utf-8"), help="Output board as HTML to this file")
     return argp.parse_args()
 
 

--- a/cruziwords/view/template.html
+++ b/cruziwords/view/template.html
@@ -46,7 +46,7 @@ from cruziwords.puzzle import Direction, Letter, WordEnd, WordStart
         <td class="empty"></td>
     % elif type(cell) is WordStart:
         <td class="word_start" title="${cell.word.clue}" style="background-color: ${color(cell.word)}">
-            ${('▶ ' if cell.dir == Direction.ACROSS else '▼ ') + cell.word.clue}
+            ${('&#9654; ' if cell.dir == Direction.ACROSS else '&#9660; ') + cell.word.clue}
         </td>
     % elif type(cell) is Letter:
         <td class="letter" style="background-color: ${color(*cell.words)}"><input type="text"/></td>

--- a/cruziwords/words.py
+++ b/cruziwords/words.py
@@ -79,7 +79,7 @@ class WordsCorpus:
                     if definition and alt_word:
                         yield Word(row[0], alt_word)
 
-        with open(csv_path, "r") as csv_file:
+        with open(csv_path, "r", encoding="utf-8") as csv_file:
             csv_reader = csv.reader(csv_file)
             words = words_from_csv()
             return cls(words)


### PR DESCRIPTION
Different machines can have different default encodings. So for some letters to be recognized, force the encoding to be utf-8 in input and output files, as well as using the unicode for the triangle sign that indicates direction. 