### PR TITLE
normalize feature

### DIFF
--- a/cruziwords/words.py
+++ b/cruziwords/words.py
@@ -16,7 +16,6 @@ def normalize(raw_solution: str) -> str:
     raw_solution_upper = re.sub(u"[ÒÓÔÕ]", "O", raw_solution_upper)
     raw_solution_upper = re.sub(u"[ÙÚÛ]", "U", raw_solution_upper)
     raw_solution_upper = re.sub(u"[ÝŸ]", "Y", raw_solution_upper)
-    # raw_solution_upper = re.sub(u"[ß]", 'SS', raw_solution)
     raw_solution_upper = re.sub("Ä", "AE", raw_solution_upper)  # Replace pattern Ä -> AE as in German
     raw_solution_upper = re.sub("Ü", "UE", raw_solution_upper)  # Replace pattern Ü -> UE as in German
     raw_solution_upper = re.sub("Ö", "OE", raw_solution_upper)  # Replace pattern Ö -> OE as in German

--- a/cruziwords/words.py
+++ b/cruziwords/words.py
@@ -1,5 +1,26 @@
-import csv
+import csv, re
 from typing import Any, Iterable, NamedTuple
+
+
+def normalize(raw_solution: str) -> str:
+    """
+    Method that normalizes the solutions used in the puzzle taken that the input file does not have a defined final format
+    In many languages the accents in vowels are omitted in crosswords puzzles, letters are considered uppercase only etc
+    Valid for French, Italian, Spanish, German ...
+    source https://en.wikipedia.org/wiki/Crossword#Orthography
+    """
+    raw_solution_upper = raw_solution.upper()
+    raw_solution_upper = re.sub(u"[ÀÁÂÃÅ]", "A", raw_solution_upper)
+    raw_solution_upper = re.sub(u"[ÈÉÊ]", "E", raw_solution_upper)
+    raw_solution_upper = re.sub(u"[ÌÍÎ]", "I", raw_solution_upper)
+    raw_solution_upper = re.sub(u"[ÒÓÔÕ]", "O", raw_solution_upper)
+    raw_solution_upper = re.sub(u"[ÙÚÛ]", "U", raw_solution_upper)
+    raw_solution_upper = re.sub(u"[ÝŸ]", "Y", raw_solution_upper)
+    # raw_solution_upper = re.sub(u"[ß]", 'SS', raw_solution)
+    raw_solution_upper = re.sub("Ä", "AE", raw_solution_upper)  # Replace pattern Ä -> AE as in German
+    raw_solution_upper = re.sub("Ü", "UE", raw_solution_upper)  # Replace pattern Ü -> UE as in German
+    raw_solution_upper = re.sub("Ö", "OE", raw_solution_upper)  # Replace pattern Ö -> OE as in German
+    return raw_solution_upper
 
 
 class Word(NamedTuple):
@@ -77,7 +98,7 @@ class WordsCorpus:
                 definition = row[0]
                 for alt_word in row[1:]:
                     if definition and alt_word:
-                        yield Word(row[0], alt_word)
+                        yield Word(row[0], normalize(alt_word))
 
         with open(csv_path, "r", encoding="utf-8") as csv_file:
             csv_reader = csv.reader(csv_file)

--- a/tests/test_words.py
+++ b/tests/test_words.py
@@ -2,23 +2,26 @@ from pathlib import Path
 
 import pytest
 
-from cruziwords.words import Word, WordsCorpus
+from cruziwords.words import Word, WordsCorpus, normalize
 
 
 @pytest.fixture
 def words_csv(tmp_path) -> Path:
     csv_content = """Capital of Afghanistan,KABUL
-European Capital,BERLIN,MADRID"""
+European Capital,BERLIN,MADRID
+Spain in Spanish,españa
+To be in French,ÊTRE
+Lice in German,Läuse"""
     csv_file = tmp_path / "words.csv"
-    csv_file.write_text(csv_content)
+    csv_file.write_text(csv_content, encoding="utf-8")
     return csv_file
 
 
 def test_words(words_csv: Path):
     words = WordsCorpus.from_csv_file(str(words_csv))
 
-    assert len(words) == 3
-    assert len(set(words)) == 3
+    assert len(words) == 6
+    assert len(set(words)) == 6
 
     assert any(word.solution == "BERLIN" for word in words)
     assert any(word.solution == "MADRID" for word in words)
@@ -41,3 +44,15 @@ def test_words_containing_letter(words_csv: Path):
 
     assert {(word.solution, i) for word, i in words.containing("I")} == {("BERLIN", 4), ("MADRID", 4)}
     assert not set(words.containing("X"))
+
+
+def test_normalisation(words_csv: Path):
+    words = WordsCorpus.from_csv_file(words_csv)
+    accented_string = "àéêhelloñçëïßäöü"
+
+    assert normalize(accented_string) == "AEEHELLOÑÇËÏSSAEOEUE"
+    assert normalize(accented_string) != "AEEHELLOÑÇËÏßAEOEUE"
+
+    assert any(word.solution == "ESPAÑA" for word in words)
+    assert any(word.solution == "ETRE" for word in words)
+    assert any(word.solution == "LAEUSE" for word in words)

--- a/tests/test_words.py
+++ b/tests/test_words.py
@@ -46,12 +46,13 @@ def test_words_containing_letter(words_csv: Path):
     assert not set(words.containing("X"))
 
 
-def test_normalisation(words_csv: Path):
-    words = WordsCorpus.from_csv_file(words_csv)
+def test_normalization():
     accented_string = "àéêhelloñçëïßäöü"
 
     assert normalize(accented_string) == "AEEHELLOÑÇËÏSSAEOEUE"
-    assert normalize(accented_string) != "AEEHELLOÑÇËÏßAEOEUE"
+
+def test_corpus_normalization(words_csv: Path):
+    words = WordsCorpus.from_csv_file(words_csv)
 
     assert any(word.solution == "ESPAÑA" for word in words)
     assert any(word.solution == "ETRE" for word in words)


### PR DESCRIPTION
Added method that normalizes the solutions used in the puzzle taken that the input file does not have a defined final format
In many languages the accents in vowels are omitted in crosswords puzzles, letters are considered uppercase only etc
Valid for French, Italian, Spanish, German ...
Method also verified
    

source https://en.wikipedia.org/wiki/Crossword#Orthography